### PR TITLE
patchset for enabling multi-client rtsp

### DIFF
--- a/src/CRtspSession.h
+++ b/src/CRtspSession.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "LinkedListElement.h"
 #include "CStreamer.h"
 #include "platglue.h"
 
@@ -18,10 +19,10 @@ enum RTSP_CMD_TYPES
 #define RTSP_PARAM_STRING_MAX  200
 #define MAX_HOSTNAME_LEN       256
 
-class CRtspSession
+class CRtspSession : public LinkedListElement
 {
 public:
-    CRtspSession(SOCKET aRtspClient, CStreamer * aStreamer);
+    CRtspSession(WiFiClient& aRtspClient, CStreamer * aStreamer);
     ~CRtspSession();
 
     RTSP_CMD_TYPES Handle_RtspRequest(char const * aRequest, unsigned aRequestSize);
@@ -34,14 +35,15 @@ public:
      */
     bool handleRequests(uint32_t readTimeoutMs);
 
-    /**
-       broadcast a current frame
-     */
-    void broadcastCurrentFrame(uint32_t curMsec);
-
     bool m_streaming;
     bool m_stopped;
 
+    void    InitTransport(u_short aRtpPort, u_short aRtcpPort);
+
+    bool isTcpTransport() { return m_TcpTransport; }
+    SOCKET& getClient() { return m_RtspClient; }
+    
+    uint16_t getRtpClientPort() { return m_RtpClientPort; }
 private:
     void Init();
     bool ParseRtspRequest(char const * aRequest, unsigned aRequestSize);
@@ -55,6 +57,7 @@ private:
 
     // global session state parameters
     int m_RtspSessionID;
+    WiFiClient m_Client;
     SOCKET m_RtspClient;                                      // RTSP socket of that session
     int m_StreamID;                                           // number of simulated stream of that session
     IPPORT m_ClientRTPPort;                                  // client port for UDP based RTP transport
@@ -70,4 +73,7 @@ private:
     char m_CSeq[RTSP_PARAM_STRING_MAX];                       // RTSP command sequence number
     char m_URLHostPort[MAX_HOSTNAME_LEN];                     // host:port part of the URL
     unsigned m_ContentLength;                                 // SDP string size
+
+    uint16_t m_RtpClientPort;      // RTP receiver port on client (in host byte order!)
+    uint16_t m_RtcpClientPort;     // RTCP receiver port on client (in host byte order!)
 };

--- a/src/CStreamer.cpp
+++ b/src/CStreamer.cpp
@@ -191,6 +191,7 @@ bool CStreamer::InitUdpTransport(void)
         }
     };
     ++m_udpRefCount;
+    return true;
 }
 
 void CStreamer::ReleaseUdpTransport(void)

--- a/src/LinkedListElement.h
+++ b/src/LinkedListElement.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "platglue.h"
+#include <stdio.h>
+
+class LinkedListElement
+{
+public:
+    LinkedListElement* m_Next;
+    LinkedListElement* m_Prev;
+    
+    LinkedListElement(void)
+    {
+        m_Next = this;
+        m_Prev = this;
+        printf("LinkedListElement (%p)->(%p)->(%p)\n", m_Prev, this, m_Next);
+    }
+    
+    int NotEmpty(void)
+    {
+        return (m_Next != this);
+    }
+    
+    LinkedListElement(LinkedListElement* linkedList)
+    {
+        // add to the end of list
+        m_Prev = linkedList->m_Prev;
+        linkedList->m_Prev = this;
+        m_Prev->m_Next = this;
+        m_Next = linkedList;
+        printf("LinkedListElement (%p)->(%p)->(%p)\n", m_Prev, this, m_Next);
+    }
+    
+    ~LinkedListElement()
+    {
+       printf("~LinkedListElement(%p)->(%p)->(%p)\n", m_Prev, this, m_Next);
+       if (m_Next)
+           m_Next->m_Prev = m_Prev;
+       if (m_Prev)
+           m_Prev->m_Next = m_Next;
+       printf("~LinkedListElement after: (%p)->(%p)", m_Prev, m_Prev->m_Next);
+    }
+};

--- a/src/OV2640.cpp
+++ b/src/OV2640.cpp
@@ -100,6 +100,14 @@ camera_config_t esp32cam_ttgo_t_config{
     .jpeg_quality = 12, //0-63 lower numbers are higher quality
     .fb_count = 2       // if more than one i2s runs in continous mode.  Use only with jpeg
 };
+void OV2640::done(void)
+{
+    if (fb) {
+        //return the frame buffer back to the driver for reuse
+        esp_camera_fb_return(fb);
+        fb = NULL;
+    }
+}
 
 void OV2640::run(void)
 {

--- a/src/OV2640.h
+++ b/src/OV2640.h
@@ -19,6 +19,7 @@ public:
     ~OV2640(){
     };
     esp_err_t init(camera_config_t config);
+    void done(void);
     void run(void);
     size_t getSize(void);
     uint8_t *getfb(void);

--- a/src/OV2640Streamer.cpp
+++ b/src/OV2640Streamer.cpp
@@ -4,7 +4,7 @@
 
 
 
-OV2640Streamer::OV2640Streamer(SOCKET aClient, OV2640 &cam) : CStreamer(aClient, cam.getWidth(), cam.getHeight()), m_cam(cam)
+OV2640Streamer::OV2640Streamer(OV2640 &cam) : CStreamer(cam.getWidth(), cam.getHeight()), m_cam(cam)
 {
     printf("Created streamer width=%d, height=%d\n", cam.getWidth(), cam.getHeight());
 }
@@ -15,4 +15,5 @@ void OV2640Streamer::streamImage(uint32_t curMsec)
 
     BufPtr bytes = m_cam.getfb();
     streamFrame(bytes, m_cam.getSize(), curMsec);
+    m_cam.done();
 }

--- a/src/OV2640Streamer.h
+++ b/src/OV2640Streamer.h
@@ -9,7 +9,7 @@ class OV2640Streamer : public CStreamer
     OV2640 &m_cam;
 
 public:
-    OV2640Streamer(SOCKET aClient, OV2640 &cam);
+    OV2640Streamer(OV2640 &cam);
 
     virtual void    streamImage(uint32_t curMsec);
 };

--- a/src/SimStreamer.cpp
+++ b/src/SimStreamer.cpp
@@ -4,7 +4,7 @@
 
 
 #ifdef INCLUDE_SIMDATA
-SimStreamer::SimStreamer(SOCKET aClient, bool showBig) : CStreamer(aClient, showBig ? 800 : 640, showBig ? 600 : 480)
+SimStreamer::SimStreamer(bool showBig) : CStreamer(showBig ? 800 : 640, showBig ? 600 : 480)
 {
     m_showBig = showBig;
 }

--- a/src/SimStreamer.h
+++ b/src/SimStreamer.h
@@ -8,7 +8,7 @@ class SimStreamer : public CStreamer
 {
     bool m_showBig;
 public:
-    SimStreamer(SOCKET aClient, bool showBig);
+    SimStreamer(bool showBig);
 
     virtual void    streamImage(uint32_t curMsec);
 };


### PR DESCRIPTION
List of changes:
- added simple LinkedListElement
- CStreamer now has multiple CRTSPSessions
- CStreamer is created at setup
- reversed broadcasting - streamer if has any active CRTSPSessions will stream to them
- misc - added define for LCD_MESSAGE, so the function won't get generated when OLED is disabled

Testing setup:
- [x] AiThinker ESP32-CAM, reduced the quality to QVGA
  - [x] ESP32 over WiFi -> Router -> LAN -> VLC 4x
  - [x] ESP32 over WiFi -> Router -> WiFi -> VLC on Android

![multi-rtsp](https://user-images.githubusercontent.com/11327694/64926999-234a0380-d805-11e9-8b20-fa540aa2fd4e.PNG)
