### PR TITLE
Avoid flooding of the UDP socket

### DIFF
--- a/src/CStreamer.cpp
+++ b/src/CStreamer.cpp
@@ -253,6 +253,8 @@ void CStreamer::streamFrame(unsigned const char *data, uint32_t dataLen, uint32_
     int offset = 0;
     do {
         offset = SendRtpPacket(data, dataLen, offset, qtable0, qtable1);
+        // Add delay or UDP buffer will overflow.
+        delay(10);
     } while(offset != 0);
 
     // Increment ONLY after a full frame


### PR DESCRIPTION
Without an delay after **`SendRtpPacket`** the UDP socket is flooded with send requests and runs out of buffer. A small delay allows FreeRTOS to do a task switch and gives the UDP socket time to actually send some data.