### PR TITLE
Fix 'error sending udp packet' error Update platglue-esp32.h

### DIFF
--- a/src/platglue-esp32.h
+++ b/src/platglue-esp32.h
@@ -69,6 +69,7 @@ inline ssize_t udpsocketsend(UDPSOCKET sockfd, const void *buf, size_t len,
 {
     sockfd->beginPacket(destaddr, destport);
     sockfd->write((const uint8_t *)  buf, len);
+    delay(2);  // give esp32 time to send udp buffer before ending
     if(!sockfd->endPacket())
         printf("error sending udp packet\n");
 


### PR DESCRIPTION
Not enough time is being given between the sending of the streamed frame data and the closing of the UDP packet. Can inconsistently cause errors. A small delay is required.

Errors when viewing: rtsp://192.168.X.XXX:554/mjpeg/1

```
22:21:25.263 > error sending udp packet
22:21:25.263 > [ 41246][E][WiFiUdp.cpp:183] endPacket(): could not send data: 12
22:21:25.263 > error sending udp packet
22:21:25.416 > [ 41393][E][WiFiUdp.cpp:183] endPacket(): could not send data: 12
22:21:25.416 > error sending udp packet
```